### PR TITLE
Fix: Window Recovery Edge Cases

### DIFF
--- a/TAPSHOP-macos/services/window_service.lua
+++ b/TAPSHOP-macos/services/window_service.lua
@@ -154,6 +154,14 @@ function WindowService.isCandidateWindow(win)
   return win:isVisible() and win:isStandard() and (win:title() or ""):match("%S") ~= nil
 end
 
+function WindowService.isRecoveryCandidateWindow(win)
+  if not win then
+    return false
+  end
+
+  return win:isStandard() and (win:title() or ""):match("%S") ~= nil
+end
+
 function WindowService.waitForFrontmost(win, cfg)
   local timeoutSec = cfg.focusWaitTimeout
   local start = hs.timer.secondsSinceEpoch()

--- a/TAPSHOP-macos/state/app_state.lua
+++ b/TAPSHOP-macos/state/app_state.lua
@@ -648,7 +648,9 @@ function AppState:_restoreRecoverableWorkspacesForCandidate(win)
     return {}
   end
 
-  if not self.windowService.isCandidateWindow or not self.windowService.isCandidateWindow(win) then
+  local isRecoveryCandidateWindow = self.windowService.isRecoveryCandidateWindow
+    or self.windowService.isCandidateWindow
+  if not isRecoveryCandidateWindow or not isRecoveryCandidateWindow(win) then
     return {}
   end
 


### PR DESCRIPTION
-fullscreened or minimized windows that are recoverable do not restore as expected during parent app restarts with multiple children windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery behavior for windows, making it easier to restore workspaces from eligible windows.
  * Added a stricter check for recovery-only windows, helping avoid restoring from unsuitable windows.
  * If no eligible window is found, the app now cleanly returns no recovery candidates instead of continuing with partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->